### PR TITLE
Changed the value of the MANIFEST_REPO variable and how we use it

### DIFF
--- a/.pipelines/az-vote-cd-pipeline.yaml
+++ b/.pipelines/az-vote-cd-pipeline.yaml
@@ -8,11 +8,6 @@ resources:
       trigger:
         branches:
           - master
-  repositories:
-    - repository: Manifest
-      type: git # Set to 'github' for a GitHub repository 
-      name: arc-cicd-demo-gitops # Set to name of GitOps repository
-      ref: 'refs/heads/master'
 
 name: $(Date:yyyyMMdd)$(Rev:.r)
 

--- a/.pipelines/genmanifest-createpr-template.yaml
+++ b/.pipelines/genmanifest-createpr-template.yaml
@@ -3,7 +3,7 @@ parameters:
     default: deploy/$(Build.BuildNumber)/$(MANIFESTS_BRANCH)
     type: string
   - name: MANIFEST_DIR
-    default: $(System.DefaultWorkingDirectory)/$(MANIFESTS_REPO)
+    default: $(System.DefaultWorkingDirectory)/arc-cicd-demo-gitops
     type: string
 
 steps:
@@ -39,7 +39,7 @@ steps:
 - script: |
    echo $(System.AccessToken) | az devops login
    az devops configure --defaults organization=https://dev.azure.com/$(ORGANIZATION_NAME) project="$(PROJECT_NAME)" --use-git-aliases true
-   az repos pr create --project $(PROJECT_NAME) --repository $(MANIFESTS_REPO) --target-branch $(MANIFESTS_BRANCH) --source-branch ${{ parameters.DEPLOY_BRANCH_NAME }} --title "deployment $(Build.BuildNumber)" --auto-complete --squash
+   az repos pr create --project $(PROJECT_NAME) --repository arc-cicd-demo-gitops --target-branch $(MANIFESTS_BRANCH) --source-branch ${{ parameters.DEPLOY_BRANCH_NAME }} --title "deployment $(Build.BuildNumber)" --auto-complete --squash
   env:
     AZURE_DEVOPS_CLI_PAT: $(System.AccessToken)
   displayName: Create Pull Request   

--- a/.pipelines/genmanifest-createpr-template.yaml
+++ b/.pipelines/genmanifest-createpr-template.yaml
@@ -3,12 +3,12 @@ parameters:
     default: deploy/$(Build.BuildNumber)/$(MANIFESTS_BRANCH)
     type: string
   - name: MANIFEST_DIR
-    default: $(System.DefaultWorkingDirectory)/arc-cicd-demo-gitops
+    default: $(System.DefaultWorkingDirectory)/$(MANIFEST_REPO)
     type: string
 
 steps:
 - checkout: self
-- checkout: Manifest
+- checkout: git://$(System.TeamProject)/$(MANIFESTS_REPO)
   persistCredentials: true
 
 - task: Bash@3        
@@ -39,7 +39,7 @@ steps:
 - script: |
    echo $(System.AccessToken) | az devops login
    az devops configure --defaults organization=https://dev.azure.com/$(ORGANIZATION_NAME) project="$(PROJECT_NAME)" --use-git-aliases true
-   az repos pr create --project $(PROJECT_NAME) --repository arc-cicd-demo-gitops --target-branch $(MANIFESTS_BRANCH) --source-branch ${{ parameters.DEPLOY_BRANCH_NAME }} --title "deployment $(Build.BuildNumber)" --auto-complete --squash
+   az repos pr create --project $(PROJECT_NAME) --repository $(MANIFESTS_REPO) --target-branch $(MANIFESTS_BRANCH) --source-branch ${{ parameters.DEPLOY_BRANCH_NAME }} --title "deployment $(Build.BuildNumber)" --auto-complete --squash
   env:
     AZURE_DEVOPS_CLI_PAT: $(System.AccessToken)
   displayName: Create Pull Request   

--- a/.pipelines/genmanifest-createpr-template.yaml
+++ b/.pipelines/genmanifest-createpr-template.yaml
@@ -3,7 +3,7 @@ parameters:
     default: deploy/$(Build.BuildNumber)/$(MANIFESTS_BRANCH)
     type: string
   - name: MANIFEST_DIR
-    default: $(System.DefaultWorkingDirectory)/$(MANIFEST_REPO)
+    default: $(System.DefaultWorkingDirectory)/$(MANIFESTS_REPO)
     type: string
 
 steps:


### PR DESCRIPTION
Changed the value of the MANIFEST_REPO variable and how we checkout the manifest repo to fix an issue with the Azure Arc CI/CD tutorial to fix the CD pipeline that was failing at step “Configure Git” with the error: ##[error]Not found workingDirectory: /home/vsts/work/1/s/https:/github.com/andrehe001/arc-cicd-demo-gitops.git . It takes the value from the variable “MANIFEST_REPO”. 